### PR TITLE
fix: don't build longhorn-manager twice before packaging (backport #3226)

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -63,3 +63,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
+

--- a/.github/workflows/wont-fix.yml
+++ b/.github/workflows/wont-fix.yml
@@ -25,3 +25,17 @@ jobs:
         with:
           labels: wontfix
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clear milestone
+        if: steps.check-closed-reason.outputs.result == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              milestone: null
+            });
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wont-fix.yml
+++ b/.github/workflows/wont-fix.yml
@@ -1,0 +1,27 @@
+name: Add-Wontfix-Label-To-Not-Planned-Issue
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  add-wontfix-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if the issue was closed with reason "not planned"
+        id: check-closed-reason
+        uses: actions/github-script@v6
+        with:
+          script: |
+            if (context.payload.issue.state_reason === "not_planned") {
+              return true;
+            }
+            return false;
+
+      - name: Add wontfix label
+        if: steps.check-closed-reason.outputs.result == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: wontfix
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Which issue(s) this PR fixes:

Issue https://github.com/yyz-field/test/issues/110
What this PR does / why we need it:
Special notes for your reviewer:
Additional documentation or context
This is an automatic backport of pull request https://github.com/longhorn/longhorn-manager/pull/3226 done by [Mergify](https://mergify.com).